### PR TITLE
Fixed typo in frontend

### DIFF
--- a/src/rospec/language/frontend.py
+++ b/src/rospec/language/frontend.py
@@ -353,7 +353,7 @@ class TreeToROSpec(Interpreter):
         return args[0]
 
     @visit_children_decor
-    def parens_exr(self, args):
+    def parens_expr(self, args):
         return args[0]
 
     @visit_children_decor


### PR DESCRIPTION
Fixed typo in parsing where there was a mismatch between the rule name in the grammar and the frontend parsing